### PR TITLE
Add server and UI planning tickets

### DIFF
--- a/.ghostfinger/tickets/audio-core-cli.yaml
+++ b/.ghostfinger/tickets/audio-core-cli.yaml
@@ -1,0 +1,27 @@
+slug: audio-core-cli          # kebab-case, immutable
+title: Audio-core CLI commands  # one-line human summary
+description: |  # what & why in two sentences max
+  Add the audio-core subcommands to the CLI for launching and terminating JACK network streams.
+  Users need a straightforward interface to start (start <peer_ip> <client_name>) and stop (stop <pid>) audio sessions.
+deliverable:  # files/dirs that must exist
+  - audiomesh/cli.py  # includes audio_core group with start and stop commands
+  - tests/test_cli_audio_core.py  # unit tests mocking start_stream and stop_stream
+  - pyproject.toml  # updated with audio-core script entrypoint
+constraints:  # "don’t you dare" list
+  - Use Click for argument parsing
+  - CLI commands must call audiomesh.start_stream and audiomesh.stop_stream
+  - Catch JackError and exit with a user-friendly error message and non-zero exit code
+  - Adhere to existing style rules (black, flake8, ruff)
+  - No additional dependencies besides Click and project dev-deps
+acceptance_criteria:  # testable bullets
+  - poetry run audio-core --help exits 0 and shows start and stop commands
+  - poetry run audio-core start 127.0.0.1 foo prints a PID (mocked in tests) and exits 0
+  - poetry run audio-core stop 1234 prints confirmation on success and exits 0
+  - On JackError, audio-core start prints the error message and exits with code 1
+  - Tests in tests/test_cli_audio_core.py pass under pytest
+priority: 2  # 0-critical, 5-meh
+estimate: 1h  # human-ish guess; QA can adjust
+dependencies:  # other ticket slugs
+  - discovery-cli  # relies on CLI framework work completed
+status: todo  # todo | in-progress | blocked | done
+notes: "Ensure tests mock external processes and verify exit codes and output formatting."

--- a/.ghostfinger/tickets/ci-cd-pipeline.yaml
+++ b/.ghostfinger/tickets/ci-cd-pipeline.yaml
@@ -1,0 +1,22 @@
+slug: ci-cd-pipeline          # kebab-case, immutable
+title: CI/CD Pipeline Setup  # one-line human summary
+description: |  # what & why in two sentences max
+  Configure a GitHub Actions workflow to run lint, type checks, and tests on every push.
+  This automates quality gates and ensures code health before merges.
+deliverable:  # files/dirs that must exist
+  - .github/workflows/ci.yml  # CI definition file
+constraints:  # "don’t you dare" list
+  - Must include steps for flake8, mypy, black check (--check), pytest
+  - Pipeline should run on pushes and PRs to main branch
+acceptance_criteria:  # testable bullets
+  - Workflow triggers on push and pull_request events
+  - flake8 step passes with zero errors or fails pipeline
+  - mypy step passes with zero type issues
+  - black --check . passes or fails pipeline
+  - pytest --maxfail=1 --disable-warnings -q passes all tests
+priority: 2  # 0-critical, 5-meh
+estimate: 2h  # human-ish guess; QA can adjust
+dependencies:
+  - fastapi-server-endpoints
+status: todo  # todo | in-progress | blocked | done
+notes: "Include cache of Poetry dependencies to speed up builds."

--- a/.ghostfinger/tickets/ci-cd-pipeline.yaml
+++ b/.ghostfinger/tickets/ci-cd-pipeline.yaml
@@ -14,6 +14,7 @@ acceptance_criteria:  # testable bullets
   - mypy step passes with zero type issues
   - black --check . passes or fails pipeline
   - pytest --maxfail=1 --disable-warnings -q passes all tests
+  - pytest --cov --cov-report=xml generates a coverage report
 priority: 2  # 0-critical, 5-meh
 estimate: 2h  # human-ish guess; QA can adjust
 dependencies:

--- a/.ghostfinger/tickets/fastapi-server-endpoints.yaml
+++ b/.ghostfinger/tickets/fastapi-server-endpoints.yaml
@@ -1,0 +1,26 @@
+slug: fastapi-server-endpoints          # kebab-case, immutable
+title: FastAPI Server Endpoints  # one-line human summary
+description: |  # what & why in two sentences max
+  Implement HTTP endpoints in a FastAPI app to expose discovery and audio-core functionality.
+  This enables programmatic control of peers and streams via REST.
+deliverable:  # files/dirs that must exist
+  - api/app.py  # FastAPI instantiation and startup/shutdown events
+  - api/routes.py  # route handlers for /nodes, /streams, etc.
+  - tests/test_api_endpoints.py  # unit tests for each endpoint
+constraints:  # "don’t you dare" list
+  - Use FastAPI
+  - Listener must start on app startup and stop on shutdown
+  - Endpoints must return JSON with proper HTTP status codes
+  - No blocking calls in route handlers
+acceptance_criteria:  # testable bullets
+  - GET /nodes returns 200 OK with JSON list of peers
+  - POST /nodes/{node_id}/stream returns 201 Created with PID
+  - DELETE /nodes/{node_id}/stream returns 204 No Content
+  - GET /streams returns 200 OK with active streams list
+  - Tests in tests/test_api_endpoints.py pass under pytest
+priority: 2  # 0-critical, 5-meh
+estimate: 4h  # human-ish guess; QA can adjust
+dependencies:  # other ticket slugs
+  - audio-core-cli
+status: todo  # todo | in-progress | blocked | done
+notes: "Ensure tests mock start_stream/stop_stream to avoid spawning real processes."

--- a/.ghostfinger/tickets/fastapi-server-endpoints.yaml
+++ b/.ghostfinger/tickets/fastapi-server-endpoints.yaml
@@ -4,7 +4,7 @@ description: |  # what & why in two sentences max
   Implement HTTP endpoints in a FastAPI app to expose discovery and audio-core functionality.
   This enables programmatic control of peers and streams via REST.
 deliverable:  # files/dirs that must exist
-  - api/app.py  # FastAPI instantiation and startup/shutdown events
+  - api/app.py  # FastAPI instantiation, startup/shutdown events, and mounting StaticFiles to serve UI assets
   - api/routes.py  # route handlers for /nodes, /streams, etc.
   - tests/test_api_endpoints.py  # unit tests for each endpoint
 constraints:  # "don’t you dare" list
@@ -12,6 +12,7 @@ constraints:  # "don’t you dare" list
   - Listener must start on app startup and stop on shutdown
   - Endpoints must return JSON with proper HTTP status codes
   - No blocking calls in route handlers
+  - Delegate long-running tasks (e.g., starting streams) to background tasks or a threadpool
 acceptance_criteria:  # testable bullets
   - GET /nodes returns 200 OK with JSON list of peers
   - POST /nodes/{node_id}/stream returns 201 Created with PID

--- a/.ghostfinger/tickets/web-ui-integration.yaml
+++ b/.ghostfinger/tickets/web-ui-integration.yaml
@@ -6,6 +6,7 @@ description: |  # what & why in two sentences max
 deliverable:  # files/dirs that must exist
   - ui/index.html  # updated to point to new endpoints and include WebSocket/SSE logic
   - ui/js/app.js  # fetch calls, event handlers, UI state updates
+  - ui/assets/  # CSS and image assets for styling and images
   - tests/test_ui_integration.js  # E2E tests in headless browser via Playwright or similar
 constraints:  # "don’t you dare" list
   - Use vanilla JS or existing framework in project
@@ -21,4 +22,4 @@ estimate: 6h  # human-ish guess; QA can adjust
 dependencies:
   - fastapi-server-endpoints
 status: todo  # todo | in-progress | blocked | done
-notes: "Ensure CORS and static file serving are configured in FastAPI."
+notes: "Ensure CORS and static file serving are configured in FastAPI. Handle error responses (e.g., display a toast notification if POST to /stream fails)."

--- a/.ghostfinger/tickets/web-ui-integration.yaml
+++ b/.ghostfinger/tickets/web-ui-integration.yaml
@@ -1,0 +1,24 @@
+slug: web-ui-integration          # kebab-case, immutable
+title: Web UI Integration  # one-line human summary
+description: |  # what & why in two sentences max
+  Connect the static dashboard UI to the FastAPI backend using fetch and real-time updates.
+  Users should see live peer lists and be able to start/stop streams from the browser.
+deliverable:  # files/dirs that must exist
+  - ui/index.html  # updated to point to new endpoints and include WebSocket/SSE logic
+  - ui/js/app.js  # fetch calls, event handlers, UI state updates
+  - tests/test_ui_integration.js  # E2E tests in headless browser via Playwright or similar
+constraints:  # "don’t you dare" list
+  - Use vanilla JS or existing framework in project
+  - Real-time updates via SSE or WebSocket only
+  - No new UI dependencies beyond project’s standard toolchain
+acceptance_criteria:  # testable bullets
+  - On page load, peer list is fetched and rendered correctly
+  - Clicking Connect sends POST and updates UI to "Connected" state
+  - Peer removal and stream status changes propagate in real time without refresh
+  - E2E tests in tests/test_ui_integration.js pass
+priority: 3  # 0-critical, 5-meh
+estimate: 6h  # human-ish guess; QA can adjust
+dependencies:
+  - fastapi-server-endpoints
+status: todo  # todo | in-progress | blocked | done
+notes: "Ensure CORS and static file serving are configured in FastAPI."


### PR DESCRIPTION
## Summary
- fix YAML formatting for audio-core CLI ticket
- add FastAPI server endpoints planning ticket
- add web UI integration ticket
- add CI/CD pipeline ticket

## Testing
- `pre-commit run --all-files`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_686c1a1a3fdc8329b8177eba42509686