### PR TITLE
Add new ticket definitions

### DIFF
--- a/.ghostfinger/tickets/config-management.yaml
+++ b/.ghostfinger/tickets/config-management.yaml
@@ -1,0 +1,23 @@
+slug: config-management          # kebab-case, immutable
+title: Configuration Management  # one-line human summary
+description: |
+  Centralize app settings in a configuration module using environment variables.
+  Ensures consistent defaults, validation, and easy overrides for CLI, API, and UI.
+deliverable:
+  - audiomesh/config.py
+  - api/settings.py
+  - Updates to cli.py and api/app.py to load settings from config module
+constraints:
+  - Use Pydantic BaseSettings for env var parsing and validation
+  - Defaults must match existing behavior
+  - Missing required vars cause a clear startup error
+acceptance_criteria:
+  - "CONFIG_GROUP=239.0.0.1 CONFIG_PORT=60000 ..." overrides discovery group and port in CLI and API
+  - Invalid env var values trigger a descriptive error at startup
+  - Unit tests for config parsing and defaults pass under pytest
+priority: 3
+estimate: 2h
+dependencies:
+  - fastapi-server-endpoints
+status: todo
+notes: ""

--- a/.ghostfinger/tickets/docker-compose-setup.yaml
+++ b/.ghostfinger/tickets/docker-compose-setup.yaml
@@ -1,0 +1,23 @@
+slug: docker-compose-setup     # kebab-case, immutable
+title: Docker Compose Setup   # one-line human summary
+description: |
+  Provide a docker-compose configuration for local development,
+  orchestrating the API, UI, and an optional dummy announcer service.
+deliverable:
+  - docker-compose.yml
+  - Dockerfile (adjusted if necessary for multi-service)
+constraints:
+  - Use `python:3.10-slim` for service images
+  - Mount local code for live reload
+  - Expose API on port 8000 and UI on port 8080
+acceptance_criteria:
+  - `docker-compose up` successfully starts all services
+  - Accessing http://localhost:8000/ returns the UI home page
+  - Stopping compose cleans up all containers
+priority: 3
+estimate: 2h
+dependencies:
+  - fastapi-server-endpoints
+  - web-ui-integration
+status: todo
+notes: ""

--- a/.ghostfinger/tickets/docs-update.yaml
+++ b/.ghostfinger/tickets/docs-update.yaml
@@ -1,0 +1,27 @@
+slug: docs-update              # kebab-case, immutable
+title: Documentation Update    # one-line human summary
+description: |
+  Enhance project documentation with comprehensive usage examples for CLI,
+  API endpoints, Docker Compose, and configuration settings.
+deliverable:
+  - README.md  # updated with CLI, API, UI, Docker usage
+  - docs/CLI.md
+  - docs/API.md
+  - docs/Deploy.md
+constraints:
+  - Use markdown format
+  - Include code snippets and expected outputs
+  - Keep prose concise and targeted at new contributors
+acceptance_criteria:
+  - README.md covers all `discovery`, `audio-core`, and `api` commands with examples
+  - docs/CLI.md, API.md, Deploy.md render correctly in GitHub preview
+  - No broken links or missing sections
+priority: 4
+estimate: 2h
+dependencies:
+  - audio-core-cli
+  - fastapi-server-endpoints
+  - web-ui-integration
+  - docker-compose-setup
+status: todo
+notes: ""

--- a/.ghostfinger/tickets/e2e-smoke-tests.yaml
+++ b/.ghostfinger/tickets/e2e-smoke-tests.yaml
@@ -1,0 +1,21 @@
+slug: e2e-smoke-tests          # kebab-case, immutable
+title: End-to-End Smoke Tests  # one-line human summary
+description: |
+  Create a smoke test suite that launches a dummy announcer and the API server,
+  then exercises HTTP endpoints to verify core workflows end-to-end.
+deliverable:
+  - tests/test_e2e_smoke.py
+  - scripts/run_e2e.sh
+constraints:
+  - Tests must be self-contained (no external network)
+  - Use pytest fixtures to manage process setup/teardown
+  - Avoid race conditions by waiting for service readiness
+acceptance_criteria:
+  - "pytest tests/test_e2e_smoke.py" passes reliably in CI environment
+  - scripts/run_e2e.sh returns exit code 0 on success and prints a summary
+priority: 2
+estimate: 3h
+dependencies:
+  - fastapi-server-endpoints
+status: todo
+notes: ""


### PR DESCRIPTION
## Summary
- add configuration management ticket for env-based settings
- add smoke test ticket with e2e script outline
- add Docker Compose setup ticket
- add docs update ticket

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_686c232988648329a4366af7e958e610