### PR TITLE
Add audio-core CLI tests

### DIFF
--- a/audiomesh/cli.py
+++ b/audiomesh/cli.py
@@ -216,14 +216,14 @@ def stop(pid_file: Path) -> None:
 
 @click.group()
 def audio_core() -> None:
-    """Manage JACK streams via jacktrip."""
+    """Commands for managing jacktrip network streams."""
 
 
 @audio_core.command(name="start")
 @click.argument("peer_ip")
 @click.argument("client_name")
 def start_session(peer_ip: str, client_name: str) -> None:
-    """Launch a jacktrip session."""
+    """Launch a jacktrip session and print its PID."""
     try:
         pid = start_stream(peer_ip, client_name)
     except JackError as exc:
@@ -235,7 +235,7 @@ def start_session(peer_ip: str, client_name: str) -> None:
 @audio_core.command(name="stop")
 @click.argument("pid", type=int)
 def stop_session(pid: int) -> None:
-    """Terminate a jacktrip session."""
+    """Terminate a running jacktrip session."""
     try:
         stop_stream(pid)
     except JackError as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ tabulate = "^0.9"
 
 [tool.poetry.scripts]
 discovery = "audiomesh.cli:discovery"
+# expose the audio_core command group as a script
 audio-core = "audiomesh.cli:audio_core"
 api = "audiomesh.cli:api"
 

--- a/tests/test_cli_audio_core.py
+++ b/tests/test_cli_audio_core.py
@@ -1,0 +1,45 @@
+import pytest  # type: ignore[import-not-found]
+from click.testing import CliRunner
+
+from audiomesh import cli
+
+
+def test_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.audio_core, ["--help"])
+    assert result.exit_code == 0
+    assert "start" in result.output
+    assert "stop" in result.output
+
+
+def test_start_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "start_stream", lambda ip, name: 222)
+    runner = CliRunner()
+    result = runner.invoke(cli.audio_core, ["start", "127.0.0.1", "foo"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "222"
+
+
+def test_stop_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def fake_stop(pid: int) -> None:
+        calls.append(pid)
+
+    monkeypatch.setattr(cli, "stop_stream", fake_stop)
+    runner = CliRunner()
+    result = runner.invoke(cli.audio_core, ["stop", "1234"])
+    assert result.exit_code == 0
+    assert calls == [1234]
+    assert result.output.strip() == "stopped 1234"
+
+
+def test_start_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(peer_ip: str, name: str) -> int:
+        raise cli.JackError("boom")  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(cli, "start_stream", boom)
+    runner = CliRunner()
+    result = runner.invoke(cli.audio_core, ["start", "1.2.3.4", "foo"])
+    assert result.exit_code == 1
+    assert "boom" in result.output


### PR DESCRIPTION
## Summary
- add dedicated tests for audio-core CLI
- polish audio-core help text

## Testing
- `poetry run pre-commit run --files audiomesh/cli.py pyproject.toml tests/test_cli_audio_core.py`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_686c262e8dbc83298e4ba668a321cef5