### PR TITLE
Add ghostfinger tickets for install script and services

### DIFF
--- a/.ghostfinger/tickets/audio-core-cli.yaml
+++ b/.ghostfinger/tickets/audio-core-cli.yaml
@@ -23,5 +23,5 @@ priority: 2  # 0-critical, 5-meh
 estimate: 1h  # human-ish guess; QA can adjust
 dependencies:  # other ticket slugs
   - discovery-cli  # relies on CLI framework work completed
-status: todo  # todo | in-progress | blocked | done
+status: done  # todo | in-progress | blocked | done
 notes: "Ensure tests mock external processes and verify exit codes and output formatting."

--- a/.ghostfinger/tickets/audio-core-service.yaml
+++ b/.ghostfinger/tickets/audio-core-service.yaml
@@ -1,0 +1,27 @@
+slug: audio-core-service
+title: Audio-core service layer (start_stream / stop_stream)
+description: >
+  Wrap jacktrip execution behind start_stream and stop_stream helpers,
+  raising JackError on failure so the CLI stays thin.
+deliverable:
+  - audiomesh/core.py                 # defines start_stream, stop_stream, JackError
+  - tests/test_audio_core_service.py
+  - docs/audio_core.md                # usage & architecture blurb
+constraints:
+  - Use `subprocess.Popen` (detach) for jacktrip; SIGTERM for stop
+  - On missing executable raise JackError("jacktrip not installed")
+  - On bad PID raise JackError("unknown stream <pid>")
+  - Return int PID from start_stream; stop_stream returns None
+  - Follow black/ruff (E,F,I) exactly; no extra deps
+acceptance_criteria:
+  - start_stream("127.0.0.1", "foo") → mocked PID int, no exceptions
+  - stop_stream(<pid>) → sends SIGTERM (mock) and returns cleanly
+  - Missing jacktrip binary triggers JackError with correct message
+  - All new tests pass under `pytest`
+priority: 1
+estimate: 3h
+dependencies:
+  - install-prereqs-script
+  - audio-core-cli
+status: todo
+notes: "Unblocks end-to-end audio sessions once jacktrip is callable."

--- a/.ghostfinger/tickets/config-management.yaml
+++ b/.ghostfinger/tickets/config-management.yaml
@@ -12,7 +12,8 @@ constraints:
   - Defaults must match existing behavior
   - Missing required vars cause a clear startup error
 acceptance_criteria:
-  - "CONFIG_GROUP=239.0.0.1 CONFIG_PORT=60000 ..." overrides discovery group and port in CLI and API
+  - >
+    "CONFIG_GROUP=239.0.0.1 CONFIG_PORT=60000 ..." overrides discovery group and port in CLI and API
   - Invalid env var values trigger a descriptive error at startup
   - Unit tests for config parsing and defaults pass under pytest
 priority: 3

--- a/.ghostfinger/tickets/discovery-daemon.yaml
+++ b/.ghostfinger/tickets/discovery-daemon.yaml
@@ -1,0 +1,27 @@
+slug: discovery-daemon
+title: LAN discovery background service
+description: >
+  Broadcast and listen for peer presence via UDP multicast, exposing
+  start_discovery / stop_discovery utilities.
+deliverable:
+  - discovery/daemon.py               # asyncio UDP service
+  - tests/test_discovery_daemon.py
+  - docs/discovery_daemon.md
+constraints:
+  - Asyncio-based, multicast to 224.0.0.1:10000 by default
+  - start_discovery returns PID (or Task id) and backgrounds cleanly
+  - Gracefully handles network errors; JackError-style DiscoveryError on failure
+  - No extra runtime deps beyond stdlib
+  - Conform to black/ruff rules
+acceptance_criteria:
+  - start_discovery() can be invoked from tests and returns a live handle/PID
+  - stop_discovery(handle) terminates the service within 2 s
+  - Received multicast packets match JSON schema { "host": str, "port": int }
+  - All tests green under `pytest`
+priority: 2
+estimate: 4h
+dependencies:
+  - discovery-cli
+  - install-prereqs-script
+status: todo
+notes: "Lays the groundwork for automatic peer mapping."

--- a/.ghostfinger/tickets/docker-compose-setup.yaml
+++ b/.ghostfinger/tickets/docker-compose-setup.yaml
@@ -11,7 +11,8 @@ constraints:
   - Mount local code for live reload
   - Expose API on port 8000 and UI on port 8080
 acceptance_criteria:
-  - `docker-compose up` successfully starts all services
+  - >
+    `docker-compose up` successfully starts all services
   - Accessing http://localhost:8000/ returns the UI home page
   - Stopping compose cleans up all containers
 priority: 3

--- a/.ghostfinger/tickets/e2e-smoke-tests.yaml
+++ b/.ghostfinger/tickets/e2e-smoke-tests.yaml
@@ -11,7 +11,8 @@ constraints:
   - Use pytest fixtures to manage process setup/teardown
   - Avoid race conditions by waiting for service readiness
 acceptance_criteria:
-  - "pytest tests/test_e2e_smoke.py" passes reliably in CI environment
+  - >
+    "pytest tests/test_e2e_smoke.py" passes reliably in CI environment
   - scripts/run_e2e.sh returns exit code 0 on success and prints a summary
 priority: 2
 estimate: 3h

--- a/.ghostfinger/tickets/install-prereqs-script.yaml
+++ b/.ghostfinger/tickets/install-prereqs-script.yaml
@@ -1,0 +1,24 @@
+slug: install-prereqs-script
+title: Portable install script for JACK + jacktrip
+description: >
+  Provide a one-shot installer so devs can run the CLI without Docker.
+  Offload package installs from the Dockerfile to the host script.
+deliverable:
+  - scripts/install_prereqs.sh        # POSIX-shell script, idempotent
+  - docs/install.md                   # quick start guide
+  - Dockerfile                        # refactored to COPY and run script only for CI
+constraints:
+  - Pure bash (no Python); must run on Debian/Ubuntu and macOS Homebrew
+  - Detect package manager and install `jacktrip` plus JACK libs/headers
+  - Idempotent: second run exits 0 and prints "already installed"
+  - No new Python deps; style rules still apply
+acceptance_criteria:
+  - `./scripts/install_prereqs.sh` on supported host exits 0 and installs binaries
+  - Re-running the script exits 0 without reinstalling
+  - `docker build .` succeeds with trimmed Dockerfile
+  - README snippet in docs matches script usage
+priority: 0
+estimate: 1h
+dependencies: []
+status: todo
+notes: "Blocks any runtime tickets that invoke jacktrip."


### PR DESCRIPTION
## Summary
- add new tickets for install prereqs script, audio core service, discovery daemon
- mark `audio-core-cli` ticket as done
- fix YAML formatting issues in existing tickets for CI checks

## Testing
- `pre-commit run --all-files`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_686c419ee66c832994f48aa4c716aa72