### PR TITLE
Add install prereqs script and docs

### DIFF
--- a/.ghostfinger/tickets/discovery-daemon.yaml
+++ b/.ghostfinger/tickets/discovery-daemon.yaml
@@ -15,8 +15,8 @@ constraints:
   - Conform to black/ruff rules
 acceptance_criteria:
   - start_discovery() can be invoked from tests and returns a live handle/PID
-  - stop_discovery(handle) terminates the service within 2 s
-  - Received multicast packets match JSON schema { "host": str, "port": int }
+  - stop_discovery(handle) terminates the service within 2s
+  - 'Received multicast packets match JSON schema { "host": str, "port": int }'
   - All tests green under `pytest`
 priority: 2
 estimate: 4h

--- a/.ghostfinger/tickets/install-prereqs-script.yaml
+++ b/.ghostfinger/tickets/install-prereqs-script.yaml
@@ -13,9 +13,9 @@ constraints:
   - Idempotent: second run exits 0 and prints "already installed"
   - No new Python deps; style rules still apply
 acceptance_criteria:
-  - `./scripts/install_prereqs.sh` on supported host exits 0 and installs binaries
+  - "./scripts/install_prereqs.sh on supported host exits 0 and installs binaries"
   - Re-running the script exits 0 without reinstalling
-  - `docker build .` succeeds with trimmed Dockerfile
+  - "docker build . succeeds with trimmed Dockerfile"
   - README snippet in docs matches script usage
 priority: 0
 estimate: 1h

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ audiomesh is a lightweight, LAN-based audio distribution framework for Linux dev
 $ git clone https://github.com/your-org/audiomesh.git
 $ cd audiomesh
 
+
 # Install dependencies
 $ poetry install
 
@@ -36,6 +37,16 @@ $ poetry shell
 # Install git hooks
 $ pre-commit install
 ```
+
+### Install JACK & jacktrip
+
+Run the helper script to install audio prerequisites:
+
+```bash
+$ ./scripts/install_prereqs.sh
+```
+
+The script is idempotent and works on Ubuntu/Debian or macOS with Homebrew.
 
 ### Docker
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,7 @@
 FROM python:3.10-slim
 
-# Install JACK server and jacktrip for network audio streaming
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        jackd2 \
-        jacktrip \
-    && rm -rf /var/lib/apt/lists/*
+COPY scripts/install_prereqs.sh /tmp/install_prereqs.sh
+RUN /tmp/install_prereqs.sh && rm /tmp/install_prereqs.sh
 
 WORKDIR /app
 COPY . /app

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,9 @@
+# Installing JACK and jacktrip
+
+Use the helper script to install prerequisites on macOS or Debian/Ubuntu hosts. The script detects the package manager and performs an idempotent install.
+
+```bash
+$ ./scripts/install_prereqs.sh
+```
+
+Running the script again simply reports that the packages are already installed.

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+# Determine package manager
+if command -v apt-get >/dev/null 2>&1; then
+    PKG_MGR=apt
+elif command -v brew >/dev/null 2>&1; then
+    PKG_MGR=brew
+else
+    echo "Unsupported system. Please install JACK and jacktrip manually." >&2
+    exit 1
+fi
+
+# Helper to run commands with sudo if not root
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO=sudo
+else
+    SUDO=
+fi
+
+apt_install() {
+    packages="jackd2 jacktrip libjack-jackd2-dev"
+    missing=""
+    for pkg in $packages; do
+        if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+            missing="$missing $pkg"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        echo "Prerequisites already installed"
+        return
+    fi
+    echo "Installing:$missing"
+    $SUDO apt-get update
+    $SUDO apt-get install -y --no-install-recommends $missing
+}
+
+brew_install() {
+    packages="jack jacktrip"
+    missing=""
+    for pkg in $packages; do
+        if ! brew ls --versions "$pkg" >/dev/null 2>&1; then
+            missing="$missing $pkg"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        echo "Prerequisites already installed"
+        return
+    fi
+    echo "Installing:$missing"
+    brew install $missing
+}
+
+case "$PKG_MGR" in
+    apt)
+        apt_install
+        ;;
+    brew)
+        brew_install
+        ;;
+esac
+


### PR DESCRIPTION
## Summary
- add helper script to install JACK & jacktrip on host
- document installing prerequisites
- update Dockerfile to run the new script
- fix YAML syntax in tickets

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_686c4396a35c8329b170592d8ff925c6