### PR TITLE
docs(tickets): add api and license tasks

### DIFF
--- a/.ghostfinger/tickets/add-license.yaml
+++ b/.ghostfinger/tickets/add-license.yaml
@@ -1,0 +1,17 @@
+slug: add-license              # kebab-case, immutable
+title: Add project license     # one-line human summary
+description: |                # what & why in two sentences max
+  Choose and add an open-source license file (e.g., MIT) to clarify usage and contributions.
+  Ensures legal clarity for users and contributors.
+deliverable:                  # files/dirs that must exist
+  - LICENSE (in repository root)
+constraints:                  # "don't you dare" list
+  - Use the MIT license template
+acceptance_criteria:          # testable bullets
+  - `LICENSE` file present with standard MIT text
+  - README references the license by name
+priority: 5                   # 0-critical, 5-meh
+estimate: 15m                 # human-ish guess; QA can adjust
+dependencies: []              # other ticket slugs
+status: todo                  # todo | in-progress | blocked | done
+notes: ""

--- a/.ghostfinger/tickets/api-cli.yaml
+++ b/.ghostfinger/tickets/api-cli.yaml
@@ -1,0 +1,22 @@
+slug: api-cli                  # kebab-case, immutable
+title: API CLI entrypoint      # one-line human summary
+description: |                # what & why in two sentences max
+  Implement the `api` subcommand in the CLI to launch the FastAPI server.
+  Provides a consistent interface (`poetry run audiomesh api`) for starting the backend.
+deliverable:                  # files/dirs that must exist
+  - audiomesh/cli.py (with `@api` Click command)
+  - pyproject.toml (includes `api = "audiomesh.cli:api"` script entrypoint)
+constraints:                  # "don't you dare" list
+  - Use Click for argument parsing
+  - Must call `uvicorn.run()` with configurable host/port
+  - Should respect config from `audiomesh/config.py`
+acceptance_criteria:          # testable bullets
+  - `poetry run audiomesh api --help` exits 0 and shows `--host` and `--port` options
+  - Running `poetry run audiomesh api` starts the server on default host/port without error
+  - Flags `--host 0.0.0.0 --port 8000` override defaults
+priority: 2                   # 0-critical, 5-meh
+estimate: 1h                  # human-ish guess; QA can adjust
+dependencies:
+  - fastapi-server-endpoints
+status: todo                   # todo | in-progress | blocked | done
+notes: "Ensure proper exit on keyboard interrupt and log startup info."

--- a/.ghostfinger/tickets/api-health-check.yaml
+++ b/.ghostfinger/tickets/api-health-check.yaml
@@ -1,0 +1,19 @@
+slug: api-health-check         # kebab-case, immutable
+title: Health check endpoint   # one-line human summary
+description: |                # what & why in two sentences max
+  Add a `/health` endpoint to the FastAPI application for readiness and liveness probes.
+  Enables Kubernetes or load balancers to verify service health.
+deliverable:                  # files/dirs that must exist
+  - api/routes.py (includes GET `/health` route)
+constraints:                  # "don't you dare" list
+  - Must return HTTP 200 OK with JSON `{ "status": "ok" }`
+  - No external dependencies or blocking logic
+acceptance_criteria:          # testable bullets
+  - `GET /health` returns 200 with `{"status":"ok"}` payload
+  - Tests in `tests/test_api_health.py` validate the route response
+priority: 3                   # 0-critical, 5-meh
+estimate: 30m                 # human-ish guess; QA can adjust
+dependencies:
+  - fastapi-server-endpoints
+status: todo                  # todo | in-progress | blocked | done
+notes: ""

--- a/.ghostfinger/tickets/config-management.yaml
+++ b/.ghostfinger/tickets/config-management.yaml
@@ -1,24 +1,24 @@
 slug: config-management          # kebab-case, immutable
 title: Configuration Management  # one-line human summary
-description: |
+description: |                # what & why in two sentences max
   Centralize app settings in a configuration module using environment variables.
   Ensures consistent defaults, validation, and easy overrides for CLI, API, and UI.
-deliverable:
+deliverable:                  # files/dirs that must exist
   - audiomesh/config.py
   - api/settings.py
   - Updates to cli.py and api/app.py to load settings from config module
-constraints:
+constraints:                  # "don't you dare" list
   - Use Pydantic BaseSettings for env var parsing and validation
   - Defaults must match existing behavior
   - Missing required vars cause a clear startup error
-acceptance_criteria:
+acceptance_criteria:          # testable bullets
   - >
     "CONFIG_GROUP=239.0.0.1 CONFIG_PORT=60000 ..." overrides discovery group and port in CLI and API
   - Invalid env var values trigger a descriptive error at startup
   - Unit tests for config parsing and defaults pass under pytest
-priority: 3
-estimate: 2h
+priority: 3                   # 0-critical, 5-meh
+estimate: 2h                  # human-ish guess; QA can adjust
 dependencies:
   - fastapi-server-endpoints
-status: todo
+status: todo                   # todo | in-progress | blocked | done
 notes: ""

--- a/.ghostfinger/tickets/docker-compose-setup.yaml
+++ b/.ghostfinger/tickets/docker-compose-setup.yaml
@@ -1,24 +1,24 @@
 slug: docker-compose-setup     # kebab-case, immutable
 title: Docker Compose Setup   # one-line human summary
-description: |
+description: |                # what & why in two sentences max
   Provide a docker-compose configuration for local development,
   orchestrating the API, UI, and an optional dummy announcer service.
-deliverable:
+deliverable:                  # files/dirs that must exist
   - docker-compose.yml
   - Dockerfile (adjusted if necessary for multi-service)
-constraints:
+constraints:                  # "don't you dare" list
   - Use `python:3.10-slim` for service images
   - Mount local code for live reload
   - Expose API on port 8000 and UI on port 8080
-acceptance_criteria:
+acceptance_criteria:          # testable bullets
   - >
     `docker-compose up` successfully starts all services
   - Accessing http://localhost:8000/ returns the UI home page
   - Stopping compose cleans up all containers
-priority: 3
-estimate: 2h
+priority: 3                   # 0-critical, 5-meh
+estimate: 2h                  # human-ish guess; QA can adjust
 dependencies:
   - fastapi-server-endpoints
   - web-ui-integration
-status: todo
+status: todo                   # todo | in-progress | blocked | done
 notes: ""

--- a/.ghostfinger/tickets/docs-update.yaml
+++ b/.ghostfinger/tickets/docs-update.yaml
@@ -1,27 +1,27 @@
 slug: docs-update              # kebab-case, immutable
 title: Documentation Update    # one-line human summary
-description: |
+description: |                # what & why in two sentences max
   Enhance project documentation with comprehensive usage examples for CLI,
   API endpoints, Docker Compose, and configuration settings.
-deliverable:
+deliverable:                  # files/dirs that must exist
   - README.md  # updated with CLI, API, UI, Docker usage
   - docs/CLI.md
   - docs/API.md
   - docs/Deploy.md
-constraints:
+constraints:                  # "don't you dare" list
   - Use markdown format
   - Include code snippets and expected outputs
   - Keep prose concise and targeted at new contributors
-acceptance_criteria:
+acceptance_criteria:          # testable bullets
   - README.md covers all `discovery`, `audio-core`, and `api` commands with examples
   - docs/CLI.md, API.md, Deploy.md render correctly in GitHub preview
   - No broken links or missing sections
-priority: 4
-estimate: 2h
+priority: 4                   # 0-critical, 5-meh
+estimate: 2h                  # human-ish guess; QA can adjust
 dependencies:
   - audio-core-cli
   - fastapi-server-endpoints
   - web-ui-integration
   - docker-compose-setup
-status: todo
+status: todo                   # todo | in-progress | blocked | done
 notes: ""

--- a/.ghostfinger/tickets/e2e-smoke-tests.yaml
+++ b/.ghostfinger/tickets/e2e-smoke-tests.yaml
@@ -1,22 +1,22 @@
 slug: e2e-smoke-tests          # kebab-case, immutable
 title: End-to-End Smoke Tests  # one-line human summary
-description: |
+description: |                # what & why in two sentences max
   Create a smoke test suite that launches a dummy announcer and the API server,
   then exercises HTTP endpoints to verify core workflows end-to-end.
-deliverable:
+deliverable:                  # files/dirs that must exist
   - tests/test_e2e_smoke.py
   - scripts/run_e2e.sh
-constraints:
+constraints:                  # "don't you dare" list
   - Tests must be self-contained (no external network)
   - Use pytest fixtures to manage process setup/teardown
   - Avoid race conditions by waiting for service readiness
-acceptance_criteria:
+acceptance_criteria:          # testable bullets
   - >
     "pytest tests/test_e2e_smoke.py" passes reliably in CI environment
   - scripts/run_e2e.sh returns exit code 0 on success and prints a summary
-priority: 2
-estimate: 3h
+priority: 2                   # 0-critical, 5-meh
+estimate: 3h                  # human-ish guess; QA can adjust
 dependencies:
   - fastapi-server-endpoints
-status: todo
+status: todo                   # todo | in-progress | blocked | done
 notes: ""

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -59,4 +59,3 @@ case "$PKG_MGR" in
         brew_install
         ;;
 esac
-


### PR DESCRIPTION
## Summary
- add api CLI and healthcheck tasks
- document license task

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest --maxfail=1 --disable-warnings --cov=audiomesh --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_686c4c45519083298a6b621bb6134e1c